### PR TITLE
Fix: Unhandled Exception: MessageException(Invalid type. type: int?, Excepted: _BigIntImpl)

### DIFF
--- a/lib/src/protobuf/codec/decoder.dart
+++ b/lib/src/protobuf/codec/decoder.dart
@@ -158,6 +158,9 @@ extension QuickProtocolBufferResult on ProtocolBufferDecoderResult {
         return (value == 1 ? true : false) as T;
       }
     }
+    if(0 is T && value is BigInt) {
+      return (value as BigInt).toInt() as T;
+    }
     throw MessageException("Invalid type.",
         details: {"type": "$T", "Excepted": value.runtimeType.toString()});
   }


### PR DESCRIPTION
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: MessageException(Invalid type. type: int?, Excepted: _BigIntImpl)
#0      QuickProtocolBufferResult.get (package:cosmos_sdk/src/protobuf/codec/decoder.dart:161:5)
#1      QuickProtocolBufferResults.getField (package:cosmos_sdk/src/protobuf/codec/decoder.dart:111:21)
#2      new ProtobufTimestamp.deserialize (package:cosmos_sdk/src/protobuf/message/timestamp.dart:25:52)
#3      new Header.deserialize (package:cosmos_sdk/src/models/tendermint/tendermint_types/messages/header.dart:70:33)
#4      new Block.deserialize (package:cosmos_sdk/src/models/tendermint/tendermint_types/messages/block.dart:21:24)
#5      new GetLatestBlockResponse.deserialize.<anonymous closure> (package:cosmos_sdk/src/models/sdk_v1beta1/cosmos_base_tendermint_v1beta1/query/get_latest_block_response.dart:27:49)
#6      QuickProtocolBufferResult.to (package:cosmos_sdk/src/protobuf/codec/decoder.dart:193:15)
#7      new GetLatestBlockResponse.deserialize (package<…>